### PR TITLE
fix: Don't use GITHUB_TOKEN for release-please

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 name: publish
-on: release
+on:
+  release:
+    types: [released]
 
 env:
   CONTAINER_MANAGER: podman

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,5 @@ jobs:
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: node
-          package-name: ""

--- a/.github/workflows/release-trigger.yml
+++ b/.github/workflows/release-trigger.yml
@@ -1,9 +1,0 @@
-name: release-trigger
-on: release
-
-jobs:
-  trigger:
-    name: Test the trigger
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo 'triggered!'


### PR DESCRIPTION
Because events generated by a GITHUB_TOKEN will not trigger
other workflows.

[FBTLOPS-159]